### PR TITLE
Update documentation title to ChatGPT Guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# AI Guide - NRL Volunteers
+# ChatGPT Guide - NRL Volunteers
 
 > Ready-to-use AI workflows that help rugby league volunteers work faster while staying mission aligned.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: AI Guide - NRL Volunteers
+site_name: ChatGPT Guide - NRL Volunteers
 site_description: >-
   The AI Prompt Cookbook is your club or organisation's guide to getting started with
   artificial intelligence tools like ChatGPT, Claude and Gemini. Instead of starting


### PR DESCRIPTION
## Summary
- update the site title in mkdocs configuration to reference the ChatGPT Guide
- align the homepage heading with the new ChatGPT Guide branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd02395ed0832bbf90f40ab88ebc70