### PR TITLE
Update homepage hero tagline

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # ChatGPT Guide - NRL Volunteers
 
-> Ready-to-use AI workflows that help rugby league volunteers work faster while staying mission aligned.
+> Ready to use ChatGPT workflows that help rugby league volunteers work faster while staying mission aligned.
 
 ## Start here
 - [Getting started](overview/getting-started.md) – understand how the guide is structured and what each complexity level offers.


### PR DESCRIPTION
## Summary
- update the homepage hero tagline to reference ChatGPT workflows and remove the hyphenated wording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd041e3594832bb3ce5bcae1678de5